### PR TITLE
Feature/146683109/categorise cards by region

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -212,7 +212,13 @@ exports.sendMail = (req, res) => {
   const subject = `You've been served!`;
   const url = decodeURIComponent(email.url);
   const html = `
-    <h5>Wad up??</h5>
+    <h5>Wad Up?</h5>
+    <p>One of your horrible friends desperately trying to do good has invited you to play Card For Humanity (CFH). </p>
+    <p>Cards for Humanity is a fast-paced online version of the popular card game, Cards Against Humanity, that gives you the opportunity to donate to children in need - all while remaining as despicable and awkward as you naturally are.</p><br />
+    <p>Your friends are waiting! <a href="${url}">
+      Get in the game now.</a></p>
+      <p>Copyright &copy; 2017
+      <a href="https://haku-cfh-staging.herokuapp.com">HAKU CFH</a>
   `;
   const content = new helper.Content('text/html', html);
   const mail = new helper.Mail(fromEmail, subject, toEmail, content);

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -4,6 +4,8 @@
 var mongoose = require('mongoose'),
   User = mongoose.model('User');
 var avatars = require('./avatars').all();
+const helper = require('sendgrid').mail;
+const sg = require('sendgrid') (process.env.SENDGRID_API_KEY);
 
 /**
  * Auth callback
@@ -185,4 +187,43 @@ exports.user = function(req, res, next, id) {
       req.profile = user;
       next();
     });
+};
+
+// Search for a user by name
+exports.searchUser = (req, res) => {
+  req.params.playerData = JSON.parse(req.params.playerData);
+  const searchTerm = req.params.playerData.searchTerm;
+  const username = req.params.playerData.name;
+  User.find({
+    name: { $regex: `^${searchTerm}`, $options: 'i' }
+  }).exec((err, user) => {
+    if (err) return res.jsonp({ error: '403' });
+    if (!user) return res.jsonp({ error: '404' });
+    res.jsonp(user);
+  }
+  );
+};
+
+// Send mail to selected users
+exports.sendMail = (req, res) => {
+  const email = JSON.parse(req.params.email);
+  const fromEmail = new helper.Email('haku-cfh@andela.com');
+  const toEmail = new helper.Email(email.email);
+  const subject = `You've been served!`;
+  const url = decodeURIComponent(email.url);
+  const html = `
+    <h5>Wad up??</h5>
+  `;
+  const content = new helper.Content('text/html', html);
+  const mail = new helper.Mail(fromEmail, subject, toEmail, content);
+  const request = sg.emptyRequest({
+    method: 'POST',
+    path: '/v3/mail/send',
+    body: mail.toJSON()
+  });
+
+  sg.API(request, (error, response) => {
+    if (error) return res.jsonp(error);
+    return res.jsonp({ invited: true });  
+  });
 };

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -189,6 +189,13 @@ exports.user = function(req, res, next, id) {
     });
 };
 
+exports.search = (req, res) => {
+  User.find().exec((err, user) => {
+    res.jsonp(user);
+  });
+};
+
+
 // Search for a user by name
 exports.searchUser = (req, res) => {
   req.params.playerData = JSON.parse(req.params.playerData);

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -240,3 +240,8 @@ exports.sendMail = (req, res) => {
     return res.jsonp({ invited: true });  
   });
 };
+
+exports.saveRegion = (req, res) => {
+  localStorage.setItem('region', req.body.player_region);
+};
+

--- a/config/express.js
+++ b/config/express.js
@@ -6,6 +6,7 @@ var express = require('express'),
     flash = require('connect-flash'),
     helpers = require('view-helpers'),
     config = require('./config');
+ var LocalStorage = require('node-localstorage').LocalStorage;
 
 module.exports = function(app, passport, mongoose) {
     app.set('showStackError', true);
@@ -54,6 +55,11 @@ module.exports = function(app, passport, mongoose) {
 
         //connect flash for flash messages
         app.use(flash());
+
+        // Initialize localStorage
+        if (typeof localStorage === "undefined" || localStorage === null) {
+            localStorage = new LocalStorage('./scratch');
+        }
 
         //dynamic helpers
         app.use(helpers(config.app.name));

--- a/config/routes.js
+++ b/config/routes.js
@@ -98,4 +98,7 @@ module.exports = function (app, passport, auth) {
   app.post('/api/auth/signup', jwtCtrl.signup);
   app.post('/api/auth/login', jwtCtrl.login);
   app.post('/api/games/:id/start', gameDetails.saveGame);
+
+  // Route to get user's region
+  app.post('/region', users.saveRegion);
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -9,6 +9,9 @@ module.exports = function (app, passport, auth) {
   app.get('/chooseavatars', users.checkAvatar);
   app.get('/signout', users.signout);
 
+  app.get('/api/search/users/:playerData', users.searchUser);
+  app.get('/api/sendmail/:email', users.sendMail);
+
     // Setting up the users api
   app.post('/users', users.create);
   app.post('/users/avatars', users.avatars);

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -27,7 +27,7 @@ function Game(gameID, io) {
   this.winnerAutopicked = false;
   this.czar = -1; // Index in this.players
   this.playerMinLimit = 3;
-  this.playerMaxLimit = 6;
+  this.playerMaxLimit = 12;
   this.pointLimit = 5;
   this.state = "awaiting players";
   this.round = 0;

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -125,8 +125,20 @@ Game.prototype.prepareGame = function() {
       if (err) {
         console.log(err);
       }
-      self.questions = results[0];
-      self.answers = results[1];
+      if (localStorage.getItem('player_region')) {
+       if (localStorage.getItem('player_region') !== '') {
+         const newQuestion = results[0].filter(result => (result.region === localStorage.getItem('player_region')));
+         const newAnswers = results[1].filter(result => (result.region === localStorage.getItem('player_region')));
+         self.questions = newQuestion;
+         self.answers = newAnswers;
+       } else {
+         self.questions = results[0];
+         self.answers = results[1];
+       }
+     } else {
+           self.questions = results[0];
+           self.answers = results[1];
+         }
 
       self.startGame();
     });

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "passport-google-oauth": "~0.1.5",
     "passport-local": "~0.1.6",
     "passport-twitter": "~1.0.2",
+    "sendgrid": "^5.1.2",
     "sinon": "~1.7.3",
     "socket.io": "~0.9.16",
     "socket.io-client": "~0.9.16",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsonwebtoken": "^7.4.1",
     "mean-logger": "~0.0.1",
     "mongoose": "^4.10.7",
+    "node-localstorage": "^1.3.0",
     "passport": "~0.1.17",
     "passport-facebook": "~2.0.0",
     "passport-github": "~0.1.5",

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -872,3 +872,10 @@ body {
   text-transform: none !important; }
   .gradientButton .donateNow {
     border-top: 0px solid black !important; }
+
+li {
+  color: black;
+  list-style-type: none; }
+
+.text-black {
+  color: black !important; }

--- a/public/css/common.scss
+++ b/public/css/common.scss
@@ -1326,4 +1326,12 @@ body{
     }
 }
 
+li {
+  color: black;
+  list-style-type: none;
+}
+
+.text-black {
+    color: black !important;
+}
 

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -1,10 +1,12 @@
 angular.module('mean.system')
-.controller('GameController', ['$scope', 'game', '$timeout', '$location', 'MakeAWishFactsService', '$dialog', function ($scope, game, $timeout, $location, MakeAWishFactsService, $dialog) {
+.controller('GameController', ['$scope', 'game', '$timeout', '$location', 'MakeAWishFactsService', '$dialog','$http', function ($scope, game, $timeout, $location, MakeAWishFactsService, $dialog, $http) {
+    $scope.checkedBoxCount = 0;
     $scope.hasPickedCards = false;
     $scope.winningCardPicked = false;
     $scope.showTable = false;
     $scope.modalShown = false;
     $scope.game = game;
+    $scope.invitedUsers = [];
     $scope.pickedCards = [];
     var makeAWishFacts = MakeAWishFactsService.getMakeAWishFacts();
     $scope.makeAWishFact = makeAWishFacts.pop();
@@ -28,6 +30,59 @@ angular.module('mean.system')
         }
       }
     };
+
+    $scope.searchUser = () => {
+      const playerName = (game.players[game.playerIndex].username);
+      const searchTerm = $scope.searchTerm || ' ';
+      const playerData = { name: playerName, searchTerm };
+      $http.get(`/api/search/users/${JSON.stringify(playerData)}/`)
+      .success((response) => {
+        $scope.users = response.filter((player) => {
+          return player.name !== playerName;
+        });
+      });
+    };
+
+    $scope.countCheckedBox = () => {
+      const userDetails = $scope.users.filter(user => (
+        user.selected
+      ));
+      $scope.checkedBoxCount = userDetails.length;
+      if ($scope.checkedBoxCount > 10) {
+        const inviteSuccessful = $('#playerRequirement');
+        inviteSuccessful.find('.modal-body')
+        .text("You can only invite 11 friends, not a country.");
+        inviteSuccessful.modal('show');
+        }
+    };
+
+    $scope.sendMail = () => {
+    const userDetails = $scope.users.filter(user => (
+    user.selected
+  ));
+    userDetails.forEach((name) => {
+      const details = JSON.stringify(
+        { name: name.name,
+          email: name.email,
+          url: `${encodeURIComponent(window.location.href)}` });
+      $http.get(`/api/sendmail/${details}`).then((response) => {
+        if(response.data.invited === true){
+          $scope.invitedUsers.push(name.email);
+        }
+      });
+    });
+    $scope.searchString = '';
+    $scope.users = '';
+    // Close invitation modal and show mail sent information
+      const myModal = $('#users-modal');
+      myModal.modal('hide');
+
+      // show successful modal when invitations sent out successfully
+      const inviteSuccessful = $('#playerRequirement');
+      inviteSuccessful.find('.modal-body')
+      .text("Invites sent to users' email");
+      inviteSuccessful.modal('show');
+  };
 
     $scope.pointerCursorStyle = function() {
       if ($scope.isCzar() && $scope.game.state === 'waiting for czar to decide') {

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -53,7 +53,7 @@ angular.module('mean.system')
         inviteSuccessful.find('.modal-body')
         .text("You can only invite 11 friends, not a country.");
         inviteSuccessful.modal('show');
-        }
+      }
     };
 
     $scope.sendMail = () => {
@@ -76,8 +76,7 @@ angular.module('mean.system')
     // Close invitation modal and show mail sent information
       const myModal = $('#users-modal');
       myModal.modal('hide');
-
-      // show successful modal when invitations sent out successfully
+    // show successful modal when invitations sent out successfully
       const inviteSuccessful = $('#playerRequirement');
       inviteSuccessful.find('.modal-body')
       .text("Invites sent to users' email");
@@ -177,7 +176,15 @@ angular.module('mean.system')
     };
 
     $scope.startGame = function() {
+      if ($scope.game.players.length < 3) {
+        const addPlayers = $('#playerRequirement');
+        addPlayers.find('.modal-body')
+        .text("Don't be stingy. You need at least 2 friends to play this game with you");
+        addPlayers.modal('show');
+      }
+      else{
       game.startGame();
+      }
     };
 
     $scope.abandonGame = function() {

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -1,5 +1,5 @@
 angular.module('mean.system')
-.controller('IndexController', ['$scope', '$http', 'Global', '$location', 'socket', 'game', 'AvatarService', function ($scope, $http, Global, $location, socket, game, AvatarService) {
+.controller('IndexController', ['$scope', '$http', 'Global', '$location', '$window', 'socket', 'game', 'AvatarService', function ($scope, $http, Global, $location, $window, socket, game, AvatarService) {
     $scope.global = Global;
 
     $scope.playAsGuest = function() {
@@ -27,5 +27,23 @@ angular.module('mean.system')
         $http.get('/signout');
         $location.path('/');
     };
+
+    $scope.playWithFriends = function() {
+      $scope.data = { player_region: $scope.region };
+      $http.post('/region', $scope.data)
+       .success(function (data) {
+         
+       });
+       $window.location.href = '/play?custom';
+      }
+
+      $scope.playAsAGuest = function() {
+        $scope.data = { player_region: $scope.region };
+        $http.post('/region', $scope.data)
+        .success(function (data) {
+         
+        });
+         $window.location.href = '/play';
+      }
 
 }]);

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -11,7 +11,7 @@ angular.module('mean.system')
       table: [],
       czar: null,
       playerMinLimit: 3,
-      playerMaxLimit: 6,
+      playerMaxLimit: 12,
       pointLimit: null,
       state: null,
       round: 0,

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -64,6 +64,7 @@ $(document).ready(function() {
               <span ng-show="showOptions">
                  <p>*To send a private link to your friends, <a href="/signup">sign up!</a></p>
                </span>
+               <button class="btn btn-secondary" data-toggle="modal" data-target="#select-region">Play Game</button>
                <span ng-hide="showOptions">
                  <a href="/play"><div id="sign-up-btn-landing">Play Game with Strangers</div></a>
                  <a href="/play?custom"><div id="sign-up-btn-landing">Play Game with Friends</div></a>
@@ -85,7 +86,7 @@ $(document).ready(function() {
                        </span>
                      </span>
                </span>
-            </div>
+            </button>
           </div>
         </div>
       </section>
@@ -175,3 +176,28 @@ $(document).ready(function() {
   </div>
 </div>
 
+<div id="select-region" class="modal fade" role="dialog" ng-controller="IndexController">
+        <div class="modal-dialog">
+          <!-- Modal content-->
+          <div class="modal-content">
+            <div class="modal-header">
+              <span>
+              <h4 class="modal-title" style="color: #1982a5; display:inline">Select region</h4>
+           </span>
+            </div>
+            <div class="modal-body">
+              <select ng-model="region" class="form-control">
+                  <option value="NG">Nigeria</option>
+                  <option value="USA">USA</option>
+                  <option value="UK">United Kingdom</option>
+                </select>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" ng-click="playAsAGuest()" style="background-color: #69d2e8; border:none; color: #fff;" >Play As A Guest</button>
+              <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" ng-click="playWithFriends()" style="background-color: #69d2e8; border:none; color: #fff;" >Play With Friends</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+</div>

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -16,11 +16,11 @@
 
       <div id="loading-container">
         <div id="loading-gif"><img ng-src="../img/loader.gif"/></div>
-        <p><button class="invite" data-toggle="modal" data-target="#users-modal">
+        <p><button class="btn btn-secondary invite" data-toggle="modal" data-target="#users-modal">
          + Invite Players</button>
         </p>
 <!-- Send Invite Modal-->
-      <div id="users-modal" class="modal fade" role="dialog">
+      <div id="users-modal" class="modal fade text-black" role="dialog">
         <div class="modal-dialog">
           <!-- Modal content-->
           <div class="modal-content">
@@ -31,12 +31,14 @@
             </div>
             <div class="modal-body">
               <input type="text" ng-keyup="searchUser()" ng-model="searchTerm"  placeholder="Search for users here..." class="col m9"/>&nbsp;
-              <li id="users" ng-repeat="user in users" >
-                <p ng-class="{'disabled': invitedUsers.includes(user.email)}">
-                  <input type="checkbox" id="{{ user.name }}" ng-model="user.selected" ng-click="countCheckedBox()" ng-disabled="checkedBoxCount > 10"  data-toggle="popover" data-content="Don't invite a country! You can only invite 11 players." data-placement="bottom" data-trigger="focus" title="Hey Emperor!"/>
-                  <label for="{{ user.name }}">{{ user.name }}</label>
-                </p>
-              </li>
+              <ul>
+                <li id="users" ng-repeat="user in users" >
+                  <p ng-class="{'disabled': invitedUsers.includes(user.email)}">
+                    <input type="checkbox" id="{{ user.name }}" ng-model="user.selected" ng-click="countCheckedBox()" ng-disabled="checkedBoxCount > 10"  data-toggle="popover" data-content="Don't invite a country! You can only invite 11 players." data-placement="bottom" data-trigger="focus" title="Hey Emperor!"/>
+                    <label for="{{ user.name }}">{{ user.name }}</label>
+                  </p>
+                </li>
+              </ul>
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" ng-click="sendMail()" style="background-color: #69d2e8; border:none; color: #fff;" ng-disabled="checkedBoxCount < 1">Invite</button>
@@ -54,7 +56,7 @@
     </div>
 
     <!-- POP up Modal -->
-  <div id="playerRequirement" class="modal fade" role="dialog">
+  <div id="playerRequirement" class="modal fade text-black" role="dialog">
     <div class="modal-dialog">
       <!-- Modal content-->
       <div class="modal-content">

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -13,8 +13,49 @@
         <div id="player-count">{{game.players.length}} / 12 </div>
         <div id="the-word-players"> Player<span ng-if="game.players.length > 1">s</span> </div>
       </div>
+
+      <div id="loading-container">
+        <div id="loading-gif"><img ng-src="../img/loader.gif"/></div>
+        <p><button class="invite" data-toggle="modal" data-target="#users-modal">
+         + Invite Players</button>
+        </p>
+<!-- Send Invite Modal-->
+      <div id="users-modal" class="modal fade" role="dialog">
+        <div class="modal-dialog">
+          <!-- Modal content-->
+          <div class="modal-content">
+            <div class="modal-header">
+              <span>
+              <h4 class="modal-title" style="color: #1982a5; display:inline">Send Invites</h4>
+           </span>
+            </div>
+            <div class="modal-body">
+              <input type="text" ng-keyup="searchUser()" ng-model="searchTerm"  placeholder="Search for users here..." class="col m9"/>&nbsp;
+              <li id="users" ng-repeat="user in users" >
+                <p ng-class="{'disabled': invitedUsers.includes(user.email)}">
+                  <input type="checkbox" id="{{ user.name }}" ng-model="user.selected" ng-click="countCheckedBox()" ng-disabled="checkedBoxCount > 10"  data-toggle="popover" data-content="Don't invite a country! You can only invite 11 players." data-placement="bottom" data-trigger="focus" title="Hey Emperor!"/>
+                  <label for="{{ user.name }}">{{ user.name }}</label>
+                </p>
+              </li>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" ng-click="sendMail()" style="background-color: #69d2e8; border:none; color: #fff;" ng-disabled="checkedBoxCount < 1">Invite</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      </div>
+      <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride)">
+        <div id='start-game-button'>
+          Start Game</br>with {{game.players.length}} players
+        </div>
+      </div>
+    </div>
+
+
       
-      <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride) && game.players.length >= game.playerMinLimit">
+      <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride)">
         <div id='start-game-button'>
           Start Game</br>with {{game.players.length}} players
         </div>

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -53,7 +53,26 @@
       </div>
     </div>
 
-
+    <!-- POP up Modal -->
+  <div id="playerRequirement" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+      <!-- Modal content-->
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;
+          </button>
+          <h4 class="modal-title">Cards for humanity</h4>
+        </div>
+        <div class="modal-body">
+          <p></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
       
       <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride)">
         <div id='start-game-button'>

--- a/public/views/start-game.html
+++ b/public/views/start-game.html
@@ -1,5 +1,5 @@
 <div id = "startGame" ng-click="startGame()"> 
-      <div id="player-count">{{game.players.length}} / 6 </div>
+      <div id="player-count">{{game.players.length}} / 12 </div>
       <div id="the-word-players"> Players </div> 
     </div>
     <div id="loading-container">

--- a/public/views/start-game.html
+++ b/public/views/start-game.html
@@ -9,5 +9,6 @@
       <div id = 'start-game-button'> 
         Start Game with {{game.players.length}} players
       </div>
-    </div>   
+    </div>
+       
 </div>


### PR DESCRIPTION
#146683109 cards should be categorised by region

What does this PR do?

This PR adds the feature that enables users select a region, so that they get questions and answers that are peculiar to that region

Description of Task to be completed?

A player who starts a game should have the option of selecting a region for the game. This would ensure the cards are relevant to that particular geographical region.

How should this be manually tested?

When a user visits the homepage and clicks on the play game button, a modal pops up, prompting the user to select a location

Any background context you want to provide?

None

What are the relevant pivotal tracker stories?

A player who starts a game should have the option of selecting a region for the game. This would ensure the cards are relevant to that particular geographical region.


Screenshots (if appropriate)

Questions: None